### PR TITLE
Icons auf der Ergebnis-Seite lesbarer machen

### DIFF
--- a/web/src/features/result/presentation/ResultOption.tsx
+++ b/web/src/features/result/presentation/ResultOption.tsx
@@ -31,7 +31,19 @@ export const ResultOption: React.FC<PollResult> = (props) => {
             <Avatar size="large" src={profile?.avatar_url} />
           </Badge>
         </Tooltip>
-        <Typography>{content}</Typography>
+        <Typography.Title
+          level={4}
+          style={{
+            letterSpacing: '8px',
+            marginBottom: '0',
+            backgroundColor: 'var(--ant-layout-color-bg-body)',
+            padding: '0.3rem 0.8rem',
+            borderRadius: '10px',
+            border: '1px solid var(--ant-color-border-secondary)',
+          }}
+        >
+          {content}
+        </Typography.Title>
       </Flex>
     </Form.Item>
   )

--- a/web/src/features/result/presentation/ResultOption.tsx
+++ b/web/src/features/result/presentation/ResultOption.tsx
@@ -1,9 +1,8 @@
 import { TABLE_NAME } from '@/common/constants/table-name.constants'
 import { Profile } from '@/common/types/tables/profiles/profile.type'
 import { supabase } from '@/supabase'
-import { Badge, Flex, Form, Tooltip } from 'antd'
+import { Badge, Flex, Form, Tooltip, Typography } from 'antd'
 import Avatar from 'antd/es/avatar/avatar'
-import Typography from 'antd/es/typography/Typography'
 import React from 'react'
 import { PollResult } from '../domain/type/poll-result.type'
 


### PR DESCRIPTION
Wurde von @cat-miller schon in #36 implementiert. Wurde ausgelagert, für mehr Struktur.

## Screenshot
![SCR-20240913-ps](https://github.com/user-attachments/assets/08303244-0e04-4978-90d9-400b1735f91e)
